### PR TITLE
fixes #75 - kernel panic

### DIFF
--- a/functions
+++ b/functions
@@ -80,14 +80,14 @@ service_create_container() {
   else
     dokku_log_info2 "Extracting config files"
     local TEMP_DOCKER_CONTAINER_ID=$(docker create "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
-    docker cp "${TEMP_DOCKER_CONTAINER_ID}:/usr/share/elasticsearch/config/" - | tar -x -C "$SERVICE_HOST_ROOT/config" --strip-components=1
+    docker cp "${TEMP_DOCKER_CONTAINER_ID}:/usr/share/elasticsearch/config/" "$SERVICE_HOST_ROOT/"
     if [[ "$ELASTICSEARCH_MAJOR_VERSION" -eq "5" ]]; then
       docker cp "${TEMP_DOCKER_CONTAINER_ID}:/etc/elasticsearch/jvm.options" - | tar -x -C "$SERVICE_HOST_ROOT/config"
     fi
     docker rm -v "${TEMP_DOCKER_CONTAINER_ID}"
-    sed -i.bak 's#Xms2g#Xms512m#g; s#Xmx2g#Xmx512m#g' "$SERVICE_HOST_ROOT/config/jvm.options"
+    sed -i.bak 's#Xms1g#Xms512m#g; s#Xmx1g#Xmx512m#g' "$SERVICE_HOST_ROOT/config/jvm.options"
 
-    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_HOST_ROOT/data:/usr/share/elasticsearch/data" -v "$SERVICE_HOST_ROOT/config:/usr/share/elasticsearch/config" -v "$SERVICE_HOST_ROOT/config:/usr/share/elasticsearch/config" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=elasticsearch "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
+    ID=$(docker run --name "$SERVICE_NAME" -v "$SERVICE_HOST_ROOT/data:/usr/share/elasticsearch/data" -v "$SERVICE_HOST_ROOT/config:/usr/share/elasticsearch/config" --env-file="$SERVICE_ROOT/ENV" -d --restart always --label dokku=service --label dokku.service=elasticsearch "$PLUGIN_IMAGE:$PLUGIN_IMAGE_VERSION")
     echo "$ID" >"$SERVICE_ROOT/ID"
 
     if [[ "$ELASTICSEARCH_MAJOR_VERSION" -eq "5" ]]; then


### PR DESCRIPTION
There were two different problems and one cleanup item, all unrelated to the docker upgrade referenced in issue #75:
1. Line 83 wasn't copying the config files over. I changed the docker cp command to make it do so.
2. Line 88 wasn't working because the jvm.options file in the image actually has 1g rather than 2g so the sed didn't work.
3. While debugging, the -v option in line 90 that mounts that config folder was repeated twice.